### PR TITLE
Fixed Runner#handleRequest() behaviour on invalid request

### DIFF
--- a/rpc.js
+++ b/rpc.js
@@ -249,10 +249,11 @@ class Runner {
     if (typeof request === 'string') {
       p = p.then(r => this.verifyJSON(r))
     }
-    return p.then(r => this.verifyRequest(r))
-      .then(r => this.callMethod(r)
-        .then(result => this.createResultResponse(result, r.id),
-              error => this.createErrorResponse(error, r.id)))
+    return p.then(r => Promise.resolve()
+      .then(() => this.verifyRequest(r))
+      .then(() => this.callMethod(r))
+      .then(result => this.createResultResponse(result, r.id))
+      .catch(error => this.createErrorResponse(error, r.id)))
   }
 
   // Creates a response from a result.

--- a/test/core.js
+++ b/test/core.js
@@ -450,19 +450,19 @@ test("Runner: #handleRequest() produces error on invalid request", async t => {
   let response = await runner.handleRequest({
     jsonrpc: '2.0', id: 0, params: []
   })
-  t.is(response.error, 'object')
+  t.is(typeof response.error, 'object')
   t.is(response.error.code, -32600)
 
   response = await runner.handleRequest({
     jsonrpc: '2.0', id: 0, method: 'check'
   })
-  t.is(response.error, 'object')
+  t.is(typeof response.error, 'object')
   t.is(response.error.code, -32600)
 
   response = await runner.handleRequest({
     jsonrpc: '2', id: 0, method: 'check', params: []
   })
-  t.is(response.error, 'object')
+  t.is(typeof response.error, 'object')
   t.is(response.error.code, -32600)
 
   response = await runner.handleRequest({


### PR DESCRIPTION
Addresses #10. Targeting 1.0.0.

Fixes the problem with one of the failing test cases introduced during #7. See #10 for details.
