### PR TITLE
Fixed incorrect error at Runner#verifyRequest(null)

### DIFF
--- a/rpc.js
+++ b/rpc.js
@@ -209,7 +209,9 @@ class Runner {
   // Throws an object appropriate for the "error"
   // response property if the request is invalid.
   verifyRequest (request) {
-    if (typeof request !== 'object' || request instanceof Array)
+    if (typeof request !== 'object'
+        || request instanceof Array
+        || request == null)
       throw { code: -32600, message: 'Invalid request: Not a JSON Object' }
     if (request.jsonrpc !== '2.0')
       throw { code: -32600, message: 'Invalid request: Incorrect jsonrpc version' }


### PR DESCRIPTION
Addresses #9. Targeting 1.0.0.

Fixes the problem with one of the failing test cases introduced during #7. See #9 for details.

Runner#verifyRequest(null) was broken because apparently `typeof null === 'object'`, so an `if` needed an extra check.
